### PR TITLE
Enable joining sessions from listed lobbies

### DIFF
--- a/Assets/Scenes/Level-1.unity
+++ b/Assets/Scenes/Level-1.unity
@@ -585,6 +585,141 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &165494964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 165494965}
+  - component: {fileID: 165494967}
+  - component: {fileID: 165494966}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &165494965
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165494964}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2009233421}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &165494966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165494964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Ready
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 26.85
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &165494967
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165494964}
+  m_CullTransparentMesh: 1
 --- !u!1 &362118850
 GameObject:
   m_ObjectHideFlags: 0
@@ -1237,6 +1372,141 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &919885450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 919885453}
+  - component: {fileID: 919885452}
+  - component: {fileID: 919885451}
+  m_Layer: 5
+  m_Name: Match Results
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &919885451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919885450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Finding Players... '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &919885452
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919885450}
+  m_CullTransparentMesh: 1
+--- !u!224 &919885453
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919885450}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2082603021}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -61}
+  m_SizeDelta: {x: 0, y: 152.4}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!1001 &999095512
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1399,6 +1669,7 @@ RectTransform:
   - {fileID: 111015403}
   - {fileID: 111540749}
   - {fileID: 2050994024}
+  - {fileID: 2082603021}
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1419,10 +1690,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0e711c70aedd0f3479faa895d49c64c7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _waitingScreen: {fileID: 111015402}
+  _waitingScreen: {fileID: 2082603020}
   _winConditionScreen: {fileID: 111540746}
   _loseConditionScreen: {fileID: 2050994021}
   _timerText: {fileID: 1606787426}
+  _readyButton: {fileID: 2009233424}
+  _readyStatus: {fileID: 1750498189}
+  _matchResult: {fileID: 919885451}
 --- !u!1001 &1242890049
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1830,6 +2104,141 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1630528664}
   m_CullTransparentMesh: 1
+--- !u!1 &1750498186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1750498187}
+  - component: {fileID: 1750498188}
+  - component: {fileID: 1750498189}
+  m_Layer: 5
+  m_Name: ReadyStatus
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1750498187
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750498186}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2082603021}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -61}
+  m_SizeDelta: {x: 0, y: 152.4}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &1750498188
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750498186}
+  m_CullTransparentMesh: 1
+--- !u!114 &1750498189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750498186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Finding Players... '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1821887106
 GameObject:
   m_ObjectHideFlags: 0
@@ -2265,6 +2674,140 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2009233420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2009233421}
+  - component: {fileID: 2009233423}
+  - component: {fileID: 2009233422}
+  - component: {fileID: 2009233424}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2009233421
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009233420}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 165494965}
+  m_Father: {fileID: 2082603021}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -320}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2009233422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009233420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2009233423
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009233420}
+  m_CullTransparentMesh: 1
+--- !u!114 &2009233424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009233420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2009233422}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1158693835}
+        m_TargetAssemblyTypeName: RedesGame.UI.GameCanvasController, Assembly-CSharp
+        m_MethodName: ToggleReady
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2050994021
 GameObject:
   m_ObjectHideFlags: 0
@@ -2343,6 +2886,85 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2082603020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2082603021}
+  - component: {fileID: 2082603023}
+  - component: {fileID: 2082603022}
+  m_Layer: 5
+  m_Name: Lobby
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2082603021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082603020}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1750498187}
+  - {fileID: 919885453}
+  - {fileID: 2009233421}
+  m_Father: {fileID: 1158693834}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2082603022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082603020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5377358, g: 0.5377358, b: 0.5377358, a: 0.84313726}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2082603023
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082603020}
+  m_CullTransparentMesh: 1
 --- !u!4 &2125206091 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8606299070874419354, guid: 01ce1c583a998df46a1042a3078b7280, type: 3}

--- a/Assets/Scripts/Connection/NetworkHandler.cs
+++ b/Assets/Scripts/Connection/NetworkHandler.cs
@@ -28,7 +28,6 @@ public class NetworkHandler : MonoBehaviour
             GameMode = gameMode,
             Scene = sceneToLoad,
             SessionName = sessionName,
-            SessionLobby = SessionLobby.Custom,
             CustomLobbyName = "OurLobbyId",
             SceneManager = sceneManager
         });

--- a/Assets/Scripts/Connection/NetworkHandler.cs
+++ b/Assets/Scripts/Connection/NetworkHandler.cs
@@ -28,6 +28,7 @@ public class NetworkHandler : MonoBehaviour
             GameMode = gameMode,
             Scene = sceneToLoad,
             SessionName = sessionName,
+            SessionLobby = SessionLobby.Custom,
             CustomLobbyName = "OurLobbyId",
             SceneManager = sceneManager
         });
@@ -51,7 +52,7 @@ public class NetworkHandler : MonoBehaviour
     async Task JoinLobby()
     {
         string lobbyId = "OurLobbyId";
-        var result = await _runner.JoinSessionLobby(SessionLobby.Shared, lobbyId);
+        var result = await _runner.JoinSessionLobby(SessionLobby.Custom, lobbyId);
     }
 
 }

--- a/Assets/Scripts/DynamicTrap.cs
+++ b/Assets/Scripts/DynamicTrap.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using Fusion;
+using RedesGame.Damageables;
+using UnityEngine;
+
+namespace RedesGame
+{
+    public class DynamicTrap : NetworkBehaviour
+    {
+        [SerializeField] private Collider2D _damageZone;
+        [SerializeField] private SpriteRenderer _indicator;
+        [SerializeField] private float _activeDuration = 2f;
+        [SerializeField] private float _inactiveDuration = 1.5f;
+        [SerializeField] private Color _activeColor = Color.red;
+        [SerializeField] private Color _inactiveColor = Color.gray;
+
+        [Networked(OnChanged = nameof(OnTrapStateChanged))]
+        private bool IsActive { get; set; }
+
+        public override void Spawned()
+        {
+            if (_damageZone == null)
+                _damageZone = GetComponent<Collider2D>();
+
+            UpdateVisuals();
+
+            if (Object.HasStateAuthority)
+                StartCoroutine(TrapRoutine());
+        }
+
+        private IEnumerator TrapRoutine()
+        {
+            while (true)
+            {
+                IsActive = true;
+                yield return new WaitForSeconds(_activeDuration);
+
+                IsActive = false;
+                yield return new WaitForSeconds(_inactiveDuration);
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D collision)
+        {
+            if (!IsActive)
+                return;
+
+            if (collision.CompareTag("Player"))
+            {
+                collision.GetComponent<IDamageable>()?.TakeLifeDamage();
+            }
+        }
+
+        static void OnTrapStateChanged(Changed<DynamicTrap> changed)
+        {
+            changed.Behaviour.UpdateVisuals();
+        }
+
+        private void UpdateVisuals()
+        {
+            if (_damageZone != null)
+                _damageZone.enabled = IsActive;
+
+            if (_indicator != null)
+                _indicator.color = IsActive ? _activeColor : _inactiveColor;
+        }
+    }
+}

--- a/Assets/Scripts/DynamicTrap.cs.meta
+++ b/Assets/Scripts/DynamicTrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ef1c5a054c2105b4399a75538974b993
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -75,6 +75,7 @@ namespace RedesGame.Managers
 
         private void OnPlayerReadyChanged(object[] obj)
         {
+            Debug.Log($"OnPlayerReadyChanged {(bool)obj[1]} {(PlayerRef)obj[0]}");
             if (!Object.HasStateAuthority)
                 return;
 

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -1,5 +1,7 @@
-using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
 using Fusion;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace RedesGame.Managers
@@ -13,8 +15,26 @@ namespace RedesGame.Managers
         [Networked]
         private float Timer { get; set; }
 
+        [Networked]
+        private int ReadyPlayers { get; set; }
+
+        [Networked]
+        private int AlivePlayers { get; set; }
+
+        [Networked(OnChanged = nameof(OnMatchStartedChanged))]
+        private bool MatchStarted { get; set; }
+
+        [Networked(OnChanged = nameof(OnMatchEndedChanged))]
+        private bool MatchEnded { get; set; }
+
+        [Networked]
+        private PlayerRef Winner { get; set; }
+
         [Networked(OnChanged = nameof(OnAllPlayersLeft))]
         private bool AllPlayersLeft { get; set; }
+
+        private readonly Dictionary<PlayerRef, bool> _playerReadyState = new();
+        private HashSet<PlayerRef> _alivePlayers = new();
 
 
         public override void Spawned()
@@ -22,6 +42,8 @@ namespace RedesGame.Managers
             ScreenManager.Instance.Deactivate();
             EventManager.StartListening("PlayerJoined", OnPlayerJoined);
             EventManager.StartListening("GoToMainMenu", DespawnPlayers);
+            EventManager.StartListening("PlayerReadyChanged", OnPlayerReadyChanged);
+            EventManager.StartListening("PlayerEliminated", OnPlayerEliminated);
         }
         static void OnAllPlayersLeft(Changed<GameManager> changed)
         {
@@ -39,8 +61,87 @@ namespace RedesGame.Managers
 
             PlayersInGame++;
 
+            var player = (PlayerRef)obj[0];
+            if (!_playerReadyState.ContainsKey(player))
+            {
+                _playerReadyState.Add(player, false);
+            }
+
+            EventManager.TriggerEvent("ReadyStatusChanged", ReadyPlayers, PlayersInGame, _minPlayersPerGame);
+
             if (PlayersInGame >= _minPlayersPerGame)
                 EventManager.TriggerEvent("AllPlayersInGame");
+        }
+
+        private void OnPlayerReadyChanged(object[] obj)
+        {
+            if (!Object.HasStateAuthority)
+                return;
+
+            var player = (PlayerRef)obj[0];
+            var ready = (bool)obj[1];
+
+            var hadEntry = _playerReadyState.TryGetValue(player, out var wasReady);
+            if (hadEntry && wasReady == ready)
+                return;
+
+            _playerReadyState[player] = ready;
+
+            var newStateValue = ready ? 1 : 0;
+            var previousStateValue = hadEntry && wasReady ? 1 : 0;
+            ReadyPlayers += newStateValue - previousStateValue;
+
+            EvaluateMatchStart();
+            EventManager.TriggerEvent("ReadyStatusChanged", ReadyPlayers, PlayersInGame, _minPlayersPerGame);
+        }
+
+        private void EvaluateMatchStart()
+        {
+            if (MatchStarted || !Object.HasStateAuthority)
+                return;
+
+            if (PlayersInGame < _minPlayersPerGame)
+                return;
+
+            if (ReadyPlayers < PlayersInGame)
+                return;
+
+            MatchStarted = true;
+            AlivePlayers = PlayersInGame;
+            _alivePlayers = new HashSet<PlayerRef>(_playerReadyState
+                .Where(kv => kv.Value)
+                .Select(kv => kv.Key));
+        }
+
+        private void OnPlayerEliminated(object[] obj)
+        {
+            if (!Object.HasStateAuthority || !MatchStarted || MatchEnded)
+                return;
+
+            var player = (PlayerRef)obj[0];
+            if (_alivePlayers.Remove(player))
+            {
+                AlivePlayers = Mathf.Max(0, AlivePlayers - 1);
+            }
+
+            if (AlivePlayers <= 1)
+            {
+                Winner = _alivePlayers.Count == 1 ? _alivePlayers.First() : player;
+                MatchEnded = true;
+            }
+        }
+
+        static void OnMatchStartedChanged(Changed<GameManager> changed)
+        {
+            EventManager.TriggerEvent("MatchStarted");
+            ScreenManager.Instance.Activate();
+        }
+
+        static void OnMatchEndedChanged(Changed<GameManager> changed)
+        {
+            var behaviour = changed.Behaviour;
+            EventManager.TriggerEvent("MatchEnded", behaviour.Winner);
+            ScreenManager.Instance.Deactivate();
         }
 
 

--- a/Assets/Scripts/Player/NetworkPlayer.cs
+++ b/Assets/Scripts/Player/NetworkPlayer.cs
@@ -26,7 +26,7 @@ namespace RedesGame.Player
                 }
 
                 transform.name = $"{NickName}_ID_{Object.Id}";
-                EventManager.TriggerEvent("PlayerJoined");
+                EventManager.TriggerEvent("PlayerJoined", Object.InputAuthority);
             }
         }
 

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -225,7 +225,7 @@ namespace RedesGame.Player
             RPC_SetReadyState(!_isReady);
         }
 
-        [Rpc(RpcSources.InputAuthority, RpcTargets.StateAuthority)]
+        [Rpc(RpcSources.InputAuthority, RpcTargets.All)]
         private void RPC_SetReadyState(bool newReadyState, RpcInfo info = default)
         {
             _isReady = newReadyState;

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -6,6 +6,7 @@ using RedesGame.ExtensionsClass;
 using RedesGame.Managers;
 using System.Linq;
 using System.Collections;
+using UnityEngine.SceneManagement;
 
 namespace RedesGame.Player
 {
@@ -32,6 +33,7 @@ namespace RedesGame.Player
         private bool _playerDead = false;
         private int _currentIndexOfWeapon;
         private bool _isFiring;
+        private bool _isReady;
 
         private NetworkInputData _inputs;
         private float _lastFiringTime;
@@ -55,6 +57,7 @@ namespace RedesGame.Player
         {
             ScreenManager.Instance.Subscribe(this);
             EventManager.StartListening("AllPlayersInGame", OnAllPlayersInGame);
+            EventManager.StartListening("MatchStarted", OnMatchStarted);
         }
 
 
@@ -62,9 +65,16 @@ namespace RedesGame.Player
         {
             ScreenManager.Instance.Unsubscribe(this);
             EventManager.StopListening("AllPlayersInGame", OnAllPlayersInGame);
+            EventManager.StopListening("MatchStarted", OnMatchStarted);
         }
 
         private void OnAllPlayersInGame(object[] obj)
+        {
+            // Allow players to ready up once the lobby has enough people
+            _isReady = false;
+        }
+
+        private void OnMatchStarted(object[] obj)
         {
             transform.position = Extensions.GetRandomSpawnPoint();
         }
@@ -155,6 +165,7 @@ namespace RedesGame.Player
             {
                 PlayerDead = true;
                 _playerDead = true;
+                EventManager.TriggerEvent("PlayerEliminated", Object.InputAuthority);
             }
         }
 
@@ -170,7 +181,8 @@ namespace RedesGame.Player
         static void OnDeadChanged(Changed<PlayerModel> changed)
         {
             var behaviour = changed.Behaviour;
-            EventManager.TriggerEvent("Dead", behaviour._playerDead);
+            var isLocal = behaviour.Object.HasInputAuthority;
+            EventManager.TriggerEvent("Dead", isLocal);
         }
 
         private void IsCloseFromGun()
@@ -203,6 +215,21 @@ namespace RedesGame.Player
         public void Deactivate()
         {
             _isActive = false;
+        }
+
+        public void ToggleReadyState()
+        {
+            if (SceneManager.GetActiveScene().name == "MainMenu")
+                return;
+
+            RPC_SetReadyState(!_isReady);
+        }
+
+        [Rpc(RpcSources.InputAuthority, RpcTargets.StateAuthority)]
+        private void RPC_SetReadyState(bool newReadyState, RpcInfo info = default)
+        {
+            _isReady = newReadyState;
+            EventManager.TriggerEvent("PlayerReadyChanged", info.Source, newReadyState);
         }
     }
 }

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -2,6 +2,8 @@ using Fusion;
 using RedesGame.Managers;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
+using RedesGame.Player;
 
 namespace RedesGame.UI
 {
@@ -12,6 +14,11 @@ namespace RedesGame.UI
         [SerializeField] private GameObject _winConditionScreen;
         [SerializeField] private GameObject _loseConditionScreen;
         [SerializeField] private TextMeshProUGUI _timerText;
+        [SerializeField] private Button _readyButton;
+        [SerializeField] private TextMeshProUGUI _readyStatus;
+        [SerializeField] private TextMeshProUGUI _matchResult;
+
+        private bool _localReady;
 
 
         private void Awake()
@@ -20,6 +27,7 @@ namespace RedesGame.UI
             _loseConditionScreen.SetActive(false);
             _waitingScreen.SetActive(true);
             ScreenManager.Instance.Deactivate();
+            UpdateReadyStatus(0, 0, 0);
         }
 
 
@@ -28,6 +36,9 @@ namespace RedesGame.UI
             EventManager.StartListening("UpdateTimer", OnUpdateTimer);
             EventManager.StartListening("AllPlayersInGame", OnAllPlayersInGame);
             EventManager.StartListening("Dead", OnWiningCondition);
+            EventManager.StartListening("MatchStarted", OnMatchStarted);
+            EventManager.StartListening("ReadyStatusChanged", OnReadyStatusChanged);
+            EventManager.StartListening("MatchEnded", OnMatchEnded);
         }
 
 
@@ -36,30 +47,96 @@ namespace RedesGame.UI
             EventManager.StopListening("UpdateTimer", OnUpdateTimer);
             EventManager.StopListening("AllPlayersInGame", OnAllPlayersInGame);
             EventManager.StopListening("Dead", OnWiningCondition);
+            EventManager.StopListening("MatchStarted", OnMatchStarted);
+            EventManager.StopListening("ReadyStatusChanged", OnReadyStatusChanged);
+            EventManager.StopListening("MatchEnded", OnMatchEnded);
 
         }
 
-        [Rpc(RpcSources.All, RpcTargets.StateAuthority)]
         private void OnWiningCondition(object[] obj)
         {
             ScreenManager.Instance.Deactivate();
-
             if ((bool)obj[0])
+            {
                 _loseConditionScreen.SetActive(true);
-            else
-                _winConditionScreen.SetActive(true);
-
+            }
         }
 
         private void OnAllPlayersInGame(object[] obj)
         {
-            _waitingScreen.SetActive(false);
-            ScreenManager.Instance.Activate();
+            _waitingScreen.SetActive(true);
+            if (_readyButton != null)
+                _readyButton.gameObject.SetActive(true);
+            ScreenManager.Instance.Deactivate();
         }
 
         private void OnUpdateTimer(object[] obj)
         {
             _timerText.text = $"Waiting For Other Player...\n{obj[0]}";
+        }
+
+        private void OnReadyStatusChanged(object[] obj)
+        {
+            var ready = (int)obj[0];
+            var total = (int)obj[1];
+            var minRequired = (int)obj[2];
+            UpdateReadyStatus(ready, total, minRequired);
+        }
+
+        private void UpdateReadyStatus(int ready, int total, int minRequired)
+        {
+            if (_readyStatus != null)
+            {
+                _readyStatus.text = $"Ready: {ready}/{total} (min {minRequired})";
+            }
+        }
+
+        private void OnMatchStarted(object[] obj)
+        {
+            _waitingScreen.SetActive(false);
+            ScreenManager.Instance.Activate();
+        }
+
+        private void OnMatchEnded(object[] obj)
+        {
+            var winner = (PlayerRef)obj[0];
+            var isWinner = NetworkPlayer.Local != null && NetworkPlayer.Local.Object.InputAuthority == winner;
+
+            _waitingScreen.SetActive(false);
+            _matchResult?.gameObject.SetActive(true);
+            if (_matchResult != null)
+            {
+                _matchResult.text = isWinner ? "You Won!" : "You Lost";
+            }
+
+            if (isWinner)
+            {
+                _winConditionScreen.SetActive(true);
+            }
+            else
+            {
+                _loseConditionScreen.SetActive(true);
+            }
+        }
+
+        public void ToggleReady()
+        {
+            if (NetworkPlayer.Local == null)
+                return;
+
+            var model = NetworkPlayer.Local.GetComponent<PlayerModel>();
+            if (model == null)
+                return;
+
+            _localReady = !_localReady;
+            model.ToggleReadyState();
+
+            if (_readyButton != null)
+            {
+                var label = _readyButton.GetComponentInChildren<TextMeshProUGUI>();
+                if (label != null)
+                    label.text = _localReady ? "Unready" : "Ready";
+            }
         }
 
         public void SetPauseMenu(bool pause)

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -4,6 +4,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using RedesGame.Player;
+using NetworkPlayer = RedesGame.Player.NetworkPlayer;
 
 namespace RedesGame.UI
 {

--- a/Assets/Scripts/UI/Sessions/SessionInfoListUIItem.cs
+++ b/Assets/Scripts/UI/Sessions/SessionInfoListUIItem.cs
@@ -23,7 +23,9 @@ namespace RedesGame.UI.Sessions
             _sessionNameText.text = sessionInfo.Name;
             _playerCountText.text = $"{sessionInfo.PlayerCount}/{sessionInfo.MaxPlayers}";
 
-            _joinButton.gameObject.SetActive(sessionInfo.PlayerCount >= sessionInfo.MaxPlayers);
+            bool hasRoomAvailable = sessionInfo.PlayerCount < sessionInfo.MaxPlayers;
+            _joinButton.gameObject.SetActive(true);
+            _joinButton.interactable = hasRoomAvailable;
         }
 
         public void OnClick()


### PR DESCRIPTION
## Summary
- keep join buttons visible for listed sessions while disabling them only when full
- allow clicking to join a session by marking buttons interactable based on capacity

## Testing
- not run (Unity environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a1e3dbe0832abce28730f3862dba)