### PR TITLE
Delay bullet collision handling by one tick

### DIFF
--- a/Assets/Scripts/Bullet/Bullet.cs
+++ b/Assets/Scripts/Bullet/Bullet.cs
@@ -13,6 +13,7 @@ namespace RedesGame.Bullets
         private NetworkRigidbody2D _myRigidBody;
         private TrailRenderer _trailRenderer;
         private GameObject _shooter;
+        private bool _canHandleCollisions;
 
 
         public override void Spawned()
@@ -20,6 +21,15 @@ namespace RedesGame.Bullets
             base.Spawned();
             _myRigidBody = GetComponent<NetworkRigidbody2D>();
             _trailRenderer = GetComponent<TrailRenderer>();
+            _canHandleCollisions = false;
+        }
+
+        public override void FixedUpdateNetwork()
+        {
+            if (!_canHandleCollisions)
+            {
+                _canHandleCollisions = true;
+            }
         }
 
         private void DestroyBullet()
@@ -41,8 +51,9 @@ namespace RedesGame.Bullets
 
         private void OnTriggerEnter2D(Collider2D collision)
         {
+            if (!_canHandleCollisions) return;
             if (_shooter == collision.gameObject) return;
-            if (!Object && !Object.HasStateAuthority) return;
+            if (!Object || !Object.HasStateAuthority) return;
             collision.gameObject.GetComponent<IDamageable>()?.TakeForceDamage(_bulletData.ForceDamage, _myRigidBody.Rigidbody.velocity.normalized);
 
             DestroyBullet();


### PR DESCRIPTION
## Summary
- delay bullet collision handling until after the first network tick to avoid immediate despawns
- guard collision handling to require state authority before applying damage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69320cce1a10832a80e06f45b14b2269)