### PR TITLE
Guard bullet collisions until after spawn tick

### DIFF
--- a/Assets/Scripts/Bullet/Bullet.cs
+++ b/Assets/Scripts/Bullet/Bullet.cs
@@ -13,6 +13,7 @@ namespace RedesGame.Bullets
         private NetworkRigidbody2D _myRigidBody;
         private TrailRenderer _trailRenderer;
         private GameObject _shooter;
+        private int _spawnTick;
 
 
         public override void Spawned()
@@ -20,6 +21,7 @@ namespace RedesGame.Bullets
             base.Spawned();
             _myRigidBody = GetComponent<NetworkRigidbody2D>();
             _trailRenderer = GetComponent<TrailRenderer>();
+            _spawnTick = Runner.Simulation.Tick;
         }
 
         private void DestroyBullet()
@@ -39,13 +41,31 @@ namespace RedesGame.Bullets
             _trailRenderer.enabled = active;
         }
 
-        private void OnTriggerEnter2D(Collider2D collision)
+        private bool CanHandleCollision()
+        {
+            if (!Runner || !Runner.IsRunning) return false;
+            if (Runner.Simulation.Tick <= _spawnTick) return false;
+            return Object && Object.HasStateAuthority;
+        }
+
+        private void HandleCollision(Collider2D collision)
         {
             if (_shooter == collision.gameObject) return;
-            if (!Object && !Object.HasStateAuthority) return;
+            if (!CanHandleCollision()) return;
+
             collision.gameObject.GetComponent<IDamageable>()?.TakeForceDamage(_bulletData.ForceDamage, _myRigidBody.Rigidbody.velocity.normalized);
 
             DestroyBullet();
+        }
+
+        private void OnTriggerEnter2D(Collider2D collision)
+        {
+            HandleCollision(collision);
+        }
+
+        private void OnTriggerStay2D(Collider2D collision)
+        {
+            HandleCollision(collision);
         }
     }
 }


### PR DESCRIPTION
## Summary
- defer bullet collision handling until after the spawn tick to avoid same-tick despawns
- handle trigger stay events so overlaps after the first tick still apply knockback and despawn

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69320cce1a10832a80e06f45b14b2269)