### PR TITLE
Handle player leave events and fix weapon index tracking

### DIFF
--- a/Assets/Scripts/Gun/GunHandler.cs
+++ b/Assets/Scripts/Gun/GunHandler.cs
@@ -45,11 +45,15 @@ namespace RedesGame.Guns
             return gun;
         }
 
-        public void ChangeGun(PlayerModel target, int oldGunIndex,int newGunIndex)
+        public int ChangeGun(PlayerModel target, int oldGunIndex, int newGunIndex)
         {
-            _allGuns[newGunIndex].SetTarget(target);
+            var newGun = _allGuns[newGunIndex];
+            newGun.SetTarget(target);
+
             Destroy(_allGuns[oldGunIndex].gameObject);
             _allGuns.RemoveAt(oldGunIndex);
+
+            return _allGuns.IndexOf(newGun);
         }
         
         public int GetIndexForGun(Gun gunToCheck)

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -44,6 +44,7 @@ namespace RedesGame.Managers
             EventManager.StartListening("GoToMainMenu", DespawnPlayers);
             EventManager.StartListening("PlayerReadyChanged", OnPlayerReadyChanged);
             EventManager.StartListening("PlayerEliminated", OnPlayerEliminated);
+            EventManager.StartListening("PlayerLeft", OnPlayerLeft);
         }
 
         public override void Despawned(NetworkRunner runner, bool hasState)
@@ -52,6 +53,7 @@ namespace RedesGame.Managers
             EventManager.StopListening("GoToMainMenu", DespawnPlayers);
             EventManager.StopListening("PlayerReadyChanged", OnPlayerReadyChanged);
             EventManager.StopListening("PlayerEliminated", OnPlayerEliminated);
+            EventManager.StopListening("PlayerLeft", OnPlayerLeft);
         }
 
 
@@ -193,7 +195,7 @@ namespace RedesGame.Managers
 
             if (MatchStarted && !MatchEnded)
             {
-                // Si se va alguien en medio de la partida, lo tratás como eliminado
+                // Si se va alguien en medio de la partida, lo tratÃ¡s como eliminado
                 if (AlivePlayers > 0 && _alivePlayers.Count == 1)
                 {
                     Winner = _alivePlayers.First();

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -253,13 +253,11 @@ namespace RedesGame.Player
             var behaviour = changed.Behaviour;
             if (behaviour.IndexOfNewWeapon >= 0)
             {
-                GunHandler.Instance.ChangeGun(
+                behaviour._currentWeaponIndex = GunHandler.Instance.ChangeGun(
                     behaviour,
                     behaviour._currentWeaponIndex,
                     behaviour.IndexOfNewWeapon
                 );
-
-                behaviour._currentWeaponIndex = behaviour.IndexOfNewWeapon;
             }
         }
 


### PR DESCRIPTION
## Summary
- subscribe GameManager to PlayerLeft events so counts and end-state update when players disconnect
- adjust gun swap handling to return the updated index after removing the previous weapon
- update player weapon tracking to use the new index returned by the handler

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693478089944832a96fe6deb1a756c7f)