### PR TITLE
Improve lobby join handling and nickname sync

### DIFF
--- a/Assets/Scripts/Connection/NetworkRunnerHandler.cs
+++ b/Assets/Scripts/Connection/NetworkRunnerHandler.cs
@@ -4,7 +4,7 @@ using Fusion;
 using Fusion.Sockets;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using RedesGame.Player; // para SpawnNetworkPlayer si est· en ese namespace
+using RedesGame.Player; // para SpawnNetworkPlayer si est√° en ese namespace
 using System;
 
 public class NetworkRunnerHandler : MonoBehaviour, INetworkRunnerCallbacks
@@ -124,13 +124,22 @@ public class NetworkRunnerHandler : MonoBehaviour, INetworkRunnerCallbacks
     public void OnInputMissing(NetworkRunner runner, PlayerRef player, NetworkInput input) { }
     public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { }
     public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { }
-    public void OnPlayerJoined(NetworkRunner runner, PlayerRef player) { }
-    public void OnPlayerLeft(NetworkRunner runner, PlayerRef player) { }
+    public void OnPlayerJoined(NetworkRunner runner, PlayerRef player)
+    {
+        Debug.Log($"[NetworkRunnerHandler] Player joined: {player}");
+        RedesGame.Managers.EventManager.TriggerEvent("PlayerJoined", player);
+    }
+
+    public void OnPlayerLeft(NetworkRunner runner, PlayerRef player)
+    {
+        Debug.Log($"[NetworkRunnerHandler] Player left: {player}");
+        RedesGame.Managers.EventManager.TriggerEvent("PlayerLeft", player);
+    }
+
     public void OnSceneLoadDone(NetworkRunner runner) { }
     public void OnSceneLoadStart(NetworkRunner runner) { }
     public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList) { }
     public void OnShutdown(NetworkRunner runner, ShutdownReason shutdownReason) { }
     public void OnUserSimulationMessage(NetworkRunner runner, SimulationMessagePtr message) { }
-    public void OnDisconnectedFromServer(NetworkRunner runner){}
     public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ArraySegment<byte> data) {}
 }

--- a/Assets/Scripts/Connection/SpawnNetworkPlayer.cs
+++ b/Assets/Scripts/Connection/SpawnNetworkPlayer.cs
@@ -63,7 +63,7 @@ namespace RedesGame.Player
                 );
 
                 // El PlayerController vive dentro del prefab, se va a encargar del movimiento.
-                // Ac· solo nos interesa el input handler, que ya buscamos vÌa NetworkPlayer.Local.
+                // Ac√° solo nos interesa el input handler, que ya buscamos v√≠a NetworkPlayer.Local.
                 Debug.Log("[SpawnNetworkPlayer] Local player spawned");
             }
         }
@@ -92,7 +92,7 @@ namespace RedesGame.Player
             _sessionListUIHandler.ActiveCreateGameOption();
         }
 
-        // ---------- El resto de callbacks (vacÌos por ahora) ----------
+        // ---------- El resto de callbacks (vac√≠os por ahora) ----------
 
         public void OnConnectedToServer(NetworkRunner runner) { }
         public void OnConnectFailed(NetworkRunner runner, NetAddress remoteAddress, NetConnectFailedReason reason) { }
@@ -105,7 +105,6 @@ namespace RedesGame.Player
         public void OnPlayerLeft(NetworkRunner runner, PlayerRef player)
         {
             Debug.Log("[SpawnNetworkPlayer] OnPlayerLeft " + player);
-            EventManager.TriggerEvent("PlayerLeft", player);
         }
         public void OnReliableDataReceived(NetworkRunner runner, PlayerRef player, ArraySegment<byte> data) { }
         public void OnSceneLoadStart(NetworkRunner runner) { }
@@ -116,6 +115,6 @@ namespace RedesGame.Player
         public void OnUserSimulationMessage(NetworkRunner runner, SimulationMessagePtr message) { }
         public void OnObjectEnterAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { }
         public void OnObjectExitAOI(NetworkRunner runner, NetworkObject obj, PlayerRef player) { }
-        public void OnSceneLoadDone(NetworkRunner runner, SceneRef scene, SceneRef? prevScene) { } // si us·s overloads nuevos, ajustamos
+        public void OnSceneLoadDone(NetworkRunner runner, SceneRef scene, SceneRef? prevScene) { } // si us√°s overloads nuevos, ajustamos
     }
 }

--- a/Assets/Scripts/Player/NetworkPlayer.cs
+++ b/Assets/Scripts/Player/NetworkPlayer.cs
@@ -23,6 +23,19 @@ namespace RedesGame.Player
             if (IsLocal)
             {
                 Local = this;
+
+                var nick = PlayerPrefs.GetString(
+                    "PlayerNickName",
+                    $"Player_{UnityEngine.Random.Range(100000000, 999999999)}"
+                );
+
+                if (string.IsNullOrWhiteSpace(nick))
+                    nick = $"Player_{UnityEngine.Random.Range(100000000, 999999999)}";
+
+                if (nick.Length > 16)
+                    nick = nick.Substring(0, 16);
+
+                RPC_SetNickName(nick);
             }
 
             // El nombre del GameObject es solo una ayuda de debug


### PR DESCRIPTION
## Summary
- trigger player join/leave events from the runner callbacks so lobby counts stay accurate
- avoid double-dispatching leave events from the spawner callbacks
- initialize each local player’s nickname from saved preferences when spawning

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693486e98e74832a891cb38baf5afba2)