### PR TITLE
Add ammo limits and respawn logic for pickup weapons

### DIFF
--- a/Assets/Scripts/Bullet/Bullet.cs
+++ b/Assets/Scripts/Bullet/Bullet.cs
@@ -10,8 +10,10 @@ namespace RedesGame.Bullets
     public class Bullet : NetworkBehaviour
     {
         [SerializeField] private BulletDataSO _bulletData;
+        [SerializeField, Tooltip("Tiempo antes de destruirse si no impacta")] private float _lifeTime = 5f;
         [Networked] private Vector2 LaunchDirection { get; set; }
         [Networked] private PlayerRef ShooterRef { get; set; }
+        [Networked] private float ElapsedLife { get; set; }
 
         private NetworkRigidbody2D _myRigidBody;
         private TrailRenderer _trailRenderer;
@@ -26,6 +28,7 @@ namespace RedesGame.Bullets
             _trailRenderer = GetComponent<TrailRenderer>();
             _canHandleCollisions = false;
             _hasAppliedLaunch = false;
+            ElapsedLife = 0f;
 
             if (ShooterRef.IsValid && Runner.TryGetPlayerObject(ShooterRef, out var shooterObj))
             {
@@ -38,7 +41,7 @@ namespace RedesGame.Bullets
 
         public override void FixedUpdateNetwork()
         {
-            // Esperamos 1 tick de simulación antes de procesar colisiones
+            // Esperamos 1 tick de simulaciÃ³n antes de procesar colisiones
             if (!_canHandleCollisions)
             {
                 _canHandleCollisions = true;
@@ -49,6 +52,15 @@ namespace RedesGame.Bullets
             if (!_hasAppliedLaunch && LaunchDirection != Vector2.zero)
             {
                 ApplyLaunch(LaunchDirection);
+            }
+
+            if (Object.HasStateAuthority && _lifeTime > 0f)
+            {
+                ElapsedLife += Runner.DeltaTime;
+                if (ElapsedLife >= _lifeTime)
+                {
+                    DestroyBullet();
+                }
             }
         }
 
@@ -89,7 +101,7 @@ namespace RedesGame.Bullets
             if (!_canHandleCollisions) return;
             if (!Object || !Object.HasStateAuthority) return;
 
-            // Evitar golpear al dueño
+            // Evitar golpear al dueÃ±o
             if (_shooterRoot != null)
             {
                 if (collision.transform.IsChildOf(_shooterRoot))
@@ -101,7 +113,7 @@ namespace RedesGame.Bullets
             {
                 Vector2 dir = _myRigidBody.Rigidbody.velocity.normalized;
                 damageable.TakeForceDamage(_bulletData.ForceDamage, dir);
-                // Si en algún caso querés que también quite vida:
+                // Si en algÃºn caso querÃ©s que tambiÃ©n quite vida:
                 // damageable.TakeLifeDamage();
             }
 


### PR DESCRIPTION
## Summary
- add ammo tracking to guns picked up in the arena and return players to the default pistol when empty
- respawn pickup guns after a cooldown so they reappear on the map
- destroy bullets automatically after a configurable lifetime

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f210c6818832a892da0c0278fda97)