### PR TITLE
Stabilize gun pickup ammo behaviour

### DIFF
--- a/Assets/Scripts/Gun/Gun.cs
+++ b/Assets/Scripts/Gun/Gun.cs
@@ -1,6 +1,7 @@
 using RedesGame.Bullets;
 using UnityEngine;
 using RedesGame.Player;
+using System;
 using System.Collections;
 
 namespace RedesGame.Guns
@@ -10,6 +11,7 @@ namespace RedesGame.Guns
         public Bullet BulletPrefab;
         public GameObject FirePoint;
         public Sprite GunSprite;
+        [SerializeField, Tooltip("Unique identifier so all clients agree on which gun is which")] private string _gunId = string.Empty;
 
         [Header("Ammo")]
         [SerializeField, Tooltip("-1 for infinite ammo")] private int _ammoCapacity = -1;
@@ -27,6 +29,7 @@ namespace RedesGame.Guns
         public bool HasLimitedAmmo => _ammoCapacity >= 0;
         public bool HasAmmo => !HasLimitedAmmo || _currentAmmo > 0;
         public bool IsOutOfAmmo => HasLimitedAmmo && _currentAmmo <= 0;
+        public string GunId => _gunId;
 
         private void Awake()
         {
@@ -35,6 +38,17 @@ namespace RedesGame.Guns
             _spawnScale = transform.localScale;
 
             IsPickupGun = gameObject.layer == LayerMask.NameToLayer("InGameGun");
+
+            if (IsPickupGun && string.IsNullOrWhiteSpace(_gunId))
+            {
+                _gunId = $"pickup-{name}-{transform.position}";
+            }
+
+            if (IsPickupGun && _ammoCapacity < 0)
+            {
+                _ammoCapacity = 6;
+            }
+
             ResetAmmo();
         }
 
@@ -60,6 +74,11 @@ namespace RedesGame.Guns
             _targetTransform = player.PlayerBody.transform;
             transform.SetParent(player.PlayerBody.transform);
             SetLayer("Gun");
+
+            if (string.IsNullOrWhiteSpace(_gunId) && player != null)
+            {
+                _gunId = $"player-{player.Object.InputAuthority.Raw}-default";
+            }
 
             if (IsPickupGun)
             {

--- a/Assets/Scripts/Gun/Gun.cs
+++ b/Assets/Scripts/Gun/Gun.cs
@@ -56,6 +56,10 @@ namespace RedesGame.Guns
         {
             IsPickupGun = false;
             _isRespawning = false;
+
+            // Las armas iniciales (pistolas) no deben tener límite de balas.
+            _ammoCapacity = -1;
+            ResetAmmo();
         }
 
         public Vector2 GetDirection()

--- a/Assets/Scripts/Gun/Gun.cs
+++ b/Assets/Scripts/Gun/Gun.cs
@@ -52,6 +52,12 @@ namespace RedesGame.Guns
             ResetAmmo();
         }
 
+        public void MarkAsPlayerWeapon()
+        {
+            IsPickupGun = false;
+            _isRespawning = false;
+        }
+
         public Vector2 GetDirection()
         {
             bool facingRight = _owner != null ? _owner.IsFacingRight : transform.lossyScale.x >= 0f;

--- a/Assets/Scripts/Gun/GunHandler.cs
+++ b/Assets/Scripts/Gun/GunHandler.cs
@@ -47,6 +47,7 @@ namespace RedesGame.Guns
             if (_initialGunPrefab == null) return default;
 
             var gun = Instantiate(_initialGunPrefab, target.PlayerBody.transform);
+            gun.MarkAsPlayerWeapon();
             gun.SetTarget(target);
             RegisterGun(gun);
             return gun;

--- a/Assets/Scripts/Gun/GunHandler.cs
+++ b/Assets/Scripts/Gun/GunHandler.cs
@@ -22,7 +22,10 @@ namespace RedesGame.Guns
 
         private void Start()
         {
-            var gunsInGame = FindObjectsOfType<Gun>().Where(gun => gun.gameObject.layer == LayerMask.NameToLayer("InGameGun"));
+            var gunsInGame = FindObjectsOfType<Gun>()
+                .Where(gun => gun.gameObject.layer == LayerMask.NameToLayer("InGameGun"))
+                .OrderBy(gun => gun.GunId);
+
             foreach (var gun in gunsInGame)
             {
                 RegisterGun(gun);
@@ -108,7 +111,6 @@ namespace RedesGame.Guns
             {
                 _gunsById.Add(gun.GunId, gun);
                 _orderedGunIds.Add(gun.GunId);
-                _orderedGunIds.Sort();
             }
             else
             {

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -294,6 +294,14 @@ namespace RedesGame.Player
             if (newGun == _currentGun)
                 return;
 
+            // Attach visually for the input authority so the player instantly sees the pickup while
+            // the state authority processes the authoritative swap.
+            if (Object.HasInputAuthority)
+            {
+                newGun.SetTarget(this);
+                _currentGun = newGun;
+            }
+
             _currentGun = newGun;
             RPC_ChangeGun(GunHandler.Instance.GetIndexForGun(newGun));
         }
@@ -337,7 +345,10 @@ namespace RedesGame.Player
         static void OnChangeGun(Changed<PlayerModel> changed)
         {
             var behaviour = changed.Behaviour;
-            if (behaviour.IndexOfNewWeapon >= 0)
+            if (behaviour.IndexOfNewWeapon < 0)
+                return;
+
+            if (behaviour.Object.HasStateAuthority)
             {
                 var newWeaponIndex = GunHandler.Instance.ChangeGun(
                     behaviour,
@@ -350,6 +361,12 @@ namespace RedesGame.Player
                     behaviour._currentWeaponIndex = newWeaponIndex;
                     behaviour._currentGun = GunHandler.Instance.GetGunByIndex(newWeaponIndex);
                 }
+            }
+            else
+            {
+                behaviour._currentWeaponIndex = behaviour.IndexOfNewWeapon;
+                behaviour._currentGun = GunHandler.Instance.GetGunByIndex(behaviour.IndexOfNewWeapon);
+                behaviour._currentGun?.SetTarget(behaviour);
             }
         }
 


### PR DESCRIPTION
## Summary
- add persistent identifiers and default ammo limits for pickup guns so they respawn correctly and have finite shots
- register guns by deterministic ids to keep weapon switching in sync across clients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941e2ffcd2c832a9eccf891268c5f7b)