### PR TITLE
Enforce two-player sessions and enable post-match replay

### DIFF
--- a/Assets/Scripts/Connection/NetworkRunnerHandler.cs
+++ b/Assets/Scripts/Connection/NetworkRunnerHandler.cs
@@ -21,6 +21,7 @@ public class NetworkRunnerHandler : MonoBehaviour, INetworkRunnerCallbacks
     private NetworkSceneManagerDefault _sceneManager;
 
     private const string LOBBY_NAME = "OurLobbyId";
+    private const int MAX_PLAYERS_PER_GAME = 2;
 
     private void Awake()
     {
@@ -144,6 +145,7 @@ public class NetworkRunnerHandler : MonoBehaviour, INetworkRunnerCallbacks
             SessionName = sessionName,
             Scene = sceneIndex,       // Fusion 1.x usa int
             CustomLobbyName = LOBBY_NAME,
+            PlayerCount = MAX_PLAYERS_PER_GAME,
             SceneManager = _sceneManager
         };
 

--- a/Assets/Scripts/Connection/SpawnNetworkPlayer.cs
+++ b/Assets/Scripts/Connection/SpawnNetworkPlayer.cs
@@ -73,10 +73,15 @@ namespace RedesGame.Player
 
         private void TrySpawnPlayer(NetworkRunner runner, PlayerRef player)
         {
-            if (runner.TryGetPlayerObject(player, out _))
+            if (runner.TryGetPlayerObject(player, out var existingObject))
             {
-                Debug.Log($"[SpawnNetworkPlayer] Player {player} already has an object, skipping spawn");
-                return;
+                if (existingObject != null && existingObject.IsValid && existingObject.gameObject != null)
+                {
+                    Debug.Log($"[SpawnNetworkPlayer] Player {player} already has an object, skipping spawn");
+                    return;
+                }
+
+                runner.SetPlayerObject(player, null);
             }
 
             var spawnPos = Extensions.GetRandomSpawnPoint();

--- a/Assets/Scripts/Managers/DynamicCameraController.cs
+++ b/Assets/Scripts/Managers/DynamicCameraController.cs
@@ -54,6 +54,8 @@ namespace RedesGame.Managers
 
         private void LateUpdate()
         {
+            _players.RemoveAll(p => p == null || !p.IsActive || p.IsDead);
+
             if (Time.time >= _nextRefreshTime)
             {
                 RefreshTargets();

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -290,6 +290,12 @@ namespace RedesGame.Managers
 
             foreach (var player in Runner.ActivePlayers)
             {
+                if (Runner.TryGetPlayerObject(player, out var playerObject))
+                {
+                    Runner.Despawn(playerObject);
+                    Runner.SetPlayerObject(player, null);
+                }
+
                 _playerReadyState[player] = false;
             }
 

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -276,6 +276,30 @@ namespace RedesGame.Managers
 
         private void RestartMatch()
         {
+            MatchStarted = false;
+            MatchEnded = false;
+            AllPlayersLeft = false;
+            Timer = 0f;
+            ReadyPlayers = 0;
+            PlayersInGame = 0;
+            AlivePlayers = 0;
+            Winner = PlayerRef.None;
+
+            _playerReadyState.Clear();
+            _alivePlayers.Clear();
+
+            foreach (var player in Runner.ActivePlayers)
+            {
+                _playerReadyState[player] = false;
+            }
+
+            RecalculateCounts();
+
+            if (PlayersInGame >= _minPlayersPerGame)
+            {
+                EventManager.TriggerEvent("AllPlayersInGame");
+            }
+
             Runner.LoadScene(SceneManager.GetActiveScene().name);
         }
     }

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -26,7 +26,7 @@ namespace RedesGame.Player
         [SerializeField] private float _checkGunsRadius = 3f;
 
         [Header("Life")]
-        [SerializeField] private int _maxLife = 3;
+        [SerializeField, Min(1)] private int _maxLife = 3;
 
         private Gun _currentGun;
         private int _currentWeaponIndex;

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -238,6 +238,8 @@ namespace RedesGame.Player
             PlayerDead = true;
             _playerDead = true;
 
+            HandleGunDepleted();
+
             DisableRenderersAndColliders();
 
             EventManager.TriggerEvent("PlayerEliminated", Object.InputAuthority);

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -28,6 +28,8 @@ namespace RedesGame.UI
             _loseConditionScreen.SetActive(false);
             _waitingScreen.SetActive(true);
 
+            ResetReadyButton();
+
             if (ScreenManager.Instance != null)
                 ScreenManager.Instance.Deactivate();
 
@@ -53,6 +55,8 @@ namespace RedesGame.UI
                     gm.CurrentPlayersInGame,
                     gm.MinPlayersPerGame
                 );
+
+                ResetReadyButton();
             }
         }
 
@@ -89,12 +93,13 @@ namespace RedesGame.UI
             if (_readyButton != null)
             {
                 _readyButton.gameObject.SetActive(true);
+                _readyButton.interactable = true;
                 var label = _readyButton.GetComponentInChildren<TextMeshProUGUI>();
                 if (label != null)
                     label.text = "Ready";
             }
 
-            UpdateReadyStatus(0, 0, 0);
+            UpdateReadyStatus(gmReadyPlayers(), gmPlayersInGame(), gmMinPlayers());
 
             if (ScreenManager.Instance != null)
                 ScreenManager.Instance.Deactivate();
@@ -136,6 +141,7 @@ namespace RedesGame.UI
             var isWinner = NetworkPlayer.Local.Object.InputAuthority == winner;
 
             _waitingScreen.SetActive(false);
+            ResetReadyButton();
 
             if (_matchResult != null)
             {
@@ -187,6 +193,37 @@ namespace RedesGame.UI
         public void ReplayMatch()
         {
             EventManager.TriggerEvent("ReplayMatch");
+        }
+
+        private int gmReadyPlayers()
+        {
+            var gm = FindObjectOfType<RedesGame.Managers.GameManager>();
+            return gm != null ? gm.CurrentReadyPlayers : 0;
+        }
+
+        private int gmPlayersInGame()
+        {
+            var gm = FindObjectOfType<RedesGame.Managers.GameManager>();
+            return gm != null ? gm.CurrentPlayersInGame : 0;
+        }
+
+        private int gmMinPlayers()
+        {
+            var gm = FindObjectOfType<RedesGame.Managers.GameManager>();
+            return gm != null ? gm.MinPlayersPerGame : 0;
+        }
+
+        private void ResetReadyButton()
+        {
+            _localReady = false;
+
+            if (_readyButton != null)
+            {
+                _readyButton.interactable = true;
+                var label = _readyButton.GetComponentInChildren<TextMeshProUGUI>();
+                if (label != null)
+                    label.text = "Ready";
+            }
         }
     }
 }

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -84,9 +84,15 @@ namespace RedesGame.UI
         private void OnAllPlayersInGame(object[] obj)
         {
             _waitingScreen.SetActive(true);
+            _localReady = false;
 
             if (_readyButton != null)
+            {
                 _readyButton.gameObject.SetActive(true);
+                var label = _readyButton.GetComponentInChildren<TextMeshProUGUI>();
+                if (label != null)
+                    label.text = "Ready";
+            }
 
             UpdateReadyStatus(0, 0, 0);
 

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -90,6 +90,15 @@ namespace RedesGame.UI
             _waitingScreen.SetActive(true);
             _localReady = false;
 
+            if (_winConditionScreen != null)
+                _winConditionScreen.SetActive(false);
+
+            if (_loseConditionScreen != null)
+                _loseConditionScreen.SetActive(false);
+
+            if (_matchResult != null)
+                _matchResult.gameObject.SetActive(false);
+
             if (_readyButton != null)
             {
                 _readyButton.gameObject.SetActive(true);
@@ -134,7 +143,7 @@ namespace RedesGame.UI
 
         private void OnMatchEnded(object[] obj)
         {
-            if (obj.Length < 1 || NetworkPlayer.Local == null)
+            if (obj.Length < 1 || NetworkPlayer.Local == null || NetworkPlayer.Local.Object == null)
                 return;
 
             var winner = (PlayerRef)obj[0];

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -177,5 +177,10 @@ namespace RedesGame.UI
         {
             EventManager.TriggerEvent("GoToMainMenu");
         }
+
+        public void ReplayMatch()
+        {
+            EventManager.TriggerEvent("ReplayMatch");
+        }
     }
 }

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -18,6 +18,7 @@ namespace RedesGame.UI
         [SerializeField] private Button _readyButton;
         [SerializeField] private TextMeshProUGUI _readyStatus;
         [SerializeField] private TextMeshProUGUI _matchResult;
+        [SerializeField] private Button[] _replayButtons;
 
         private bool _localReady;
 
@@ -34,6 +35,17 @@ namespace RedesGame.UI
                 ScreenManager.Instance.Deactivate();
 
             UpdateReadyStatus(0, 0, 0);
+
+            if (_replayButtons != null)
+            {
+                foreach (var button in _replayButtons)
+                {
+                    if (button != null)
+                    {
+                        button.onClick.AddListener(ReplayMatch);
+                    }
+                }
+            }
         }
 
 

--- a/Assets/Scripts/UI/MenuPrincipalUI.cs
+++ b/Assets/Scripts/UI/MenuPrincipalUI.cs
@@ -35,15 +35,17 @@ namespace RedesGame.UI
         private void Awake()
         {
             Debug.Log("Awake Menu Principal UI");
-            _mainMenuButtons.SetActive(false);
+            bool hasStoredNick = PlayerPrefs.HasKey("PlayerNickName");
+
+            _mainMenuButtons.SetActive(hasStoredNick);
             _creditsScreen.SetActive(false);
             _controlsScreen.SetActive(false);
             _backButton.SetActive(false);
-            _nickNameScreen.SetActive(true);
+            _nickNameScreen.SetActive(!hasStoredNick);
             _sessionsScreen.SetActive(false);
             _createSessionScreen.SetActive(false);
             _onJoiningSessionScreen.SetActive(false);
-            _nickNameInput.gameObject.SetActive(true);
+            _nickNameInput.gameObject.SetActive(!hasStoredNick);
         }
 
         private void Start()


### PR DESCRIPTION
## Summary
- limit each Fusion session to two players and add guardrails for player life setup
- allow both players to request returning to the main menu or replaying the match via UI events handled by the host
- skip the nickname entry screen when a stored player name exists

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941f5e50c80832a99fbf54e4c3be74f)