### PR TITLE
Ensure replay reloads scene for all clients

### DIFF
--- a/Assets/Scripts/Connection/SpawnNetworkPlayer.cs
+++ b/Assets/Scripts/Connection/SpawnNetworkPlayer.cs
@@ -98,6 +98,17 @@ namespace RedesGame.Player
             Debug.Log($"[SpawnNetworkPlayer] Spawned player object for {player}");
         }
 
+        public void RespawnAllPlayers(NetworkRunner runner)
+        {
+            if (runner == null || !runner.IsServer)
+                return;
+
+            foreach (var player in runner.ActivePlayers)
+            {
+                TrySpawnPlayer(runner, player);
+            }
+        }
+
         // ---------- SESIONES / UI ----------
 
         public void OnSessionListUpdated(NetworkRunner runner, List<SessionInfo> sessionList)

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -192,6 +192,13 @@ namespace RedesGame.Managers
         static void OnMatchEndedChanged(Changed<GameManager> changed)
         {
             var behaviour = changed.Behaviour;
+            if (!behaviour.MatchEnded)
+            {
+                EventManager.TriggerEvent("MatchReset");
+                ScreenManager.Instance.Deactivate();
+                return;
+            }
+
             EventManager.TriggerEvent("MatchEnded", behaviour.Winner);
             ScreenManager.Instance.Deactivate();
         }
@@ -200,6 +207,11 @@ namespace RedesGame.Managers
         {
             var behaviour = changed.Behaviour;
             behaviour.BroadcastReadyStatus();
+
+            if (behaviour.PlayersInGame >= behaviour._minPlayersPerGame)
+            {
+                EventManager.TriggerEvent("AllPlayersInGame");
+            }
         }
 
         static void OnReadyPlayersChanged(Changed<GameManager> changed)

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -307,10 +307,11 @@ namespace RedesGame.Managers
             }
 
             // Use the runner scene loader so every client reloads the lobby together
-            // instead of only the host reloading locally.
+            // instead of only the host reloading locally. Fusion 1.x uses SetActiveScene
+            // on the runner instead of LoadScene.
             if (Runner != null && Runner.IsRunning)
             {
-                Runner.LoadScene(SceneManager.GetActiveScene().buildIndex);
+                Runner.SetActiveScene(SceneManager.GetActiveScene().buildIndex);
             }
             else
             {

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -306,7 +306,16 @@ namespace RedesGame.Managers
                 EventManager.TriggerEvent("AllPlayersInGame");
             }
 
-            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+            // Use the runner scene loader so every client reloads the lobby together
+            // instead of only the host reloading locally.
+            if (Runner != null && Runner.IsRunning)
+            {
+                Runner.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            }
+            else
+            {
+                SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+            }
         }
     }
 }

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -306,12 +306,15 @@ namespace RedesGame.Managers
                 EventManager.TriggerEvent("AllPlayersInGame");
             }
 
-            // Use the runner scene loader so every client reloads the lobby together
-            // instead of only the host reloading locally. Fusion 1.x uses SetActiveScene
-            // on the runner instead of LoadScene.
             if (Runner != null && Runner.IsRunning)
             {
                 Runner.SetActiveScene(SceneManager.GetActiveScene().buildIndex);
+
+                var spawner = Runner.GetComponent<RedesGame.Player.SpawnNetworkPlayer>();
+                if (spawner != null)
+                {
+                    spawner.RespawnAllPlayers(Runner);
+                }
             }
             else
             {

--- a/Assets/Scripts/UI/GameCanvasController.cs
+++ b/Assets/Scripts/UI/GameCanvasController.cs
@@ -45,6 +45,7 @@ namespace RedesGame.UI
             EventManager.StartListening("MatchStarted", OnMatchStarted);
             EventManager.StartListening("ReadyStatusChanged", OnReadyStatusChanged);
             EventManager.StartListening("MatchEnded", OnMatchEnded);
+            EventManager.StartListening("MatchReset", OnMatchReset);
 
             // Refrescar estado inicial desde GameManager
             var gm = FindObjectOfType<RedesGame.Managers.GameManager>();
@@ -69,6 +70,7 @@ namespace RedesGame.UI
             EventManager.StopListening("MatchStarted", OnMatchStarted);
             EventManager.StopListening("ReadyStatusChanged", OnReadyStatusChanged);
             EventManager.StopListening("MatchEnded", OnMatchEnded);
+            EventManager.StopListening("MatchReset", OnMatchReset);
 
         }
 
@@ -162,6 +164,22 @@ namespace RedesGame.UI
                 _winConditionScreen.SetActive(true);
             else
                 _loseConditionScreen.SetActive(true);
+        }
+
+        private void OnMatchReset(object[] obj)
+        {
+            _waitingScreen.SetActive(true);
+
+            if (_winConditionScreen != null)
+                _winConditionScreen.SetActive(false);
+
+            if (_loseConditionScreen != null)
+                _loseConditionScreen.SetActive(false);
+
+            if (_matchResult != null)
+                _matchResult.gameObject.SetActive(false);
+
+            ResetReadyButton();
         }
 
         public void ToggleReady()


### PR DESCRIPTION
## Summary
- reload the level through the NetworkRunner when a replay is requested so all clients reload together
- keep a local SceneManager fallback if the runner is unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bcb1d954832a87dee707cc546d21)